### PR TITLE
Remove redundant ioplacer PDN_MACRO_CONNECTIONS

### DIFF
--- a/io_placer/config.json
+++ b/io_placer/config.json
@@ -48,10 +48,6 @@
     "CLOCK_PORT": "user_clock2",
     "CLOCK_NET": "mprj1.clk",
     "CLOCK_PERIOD": "10",
-    "PDN_MACRO_CONNECTIONS": [
-        "mprj* vccd1 vssd1 vccd1 vssd1",
-        "prj2 vccd2 vssd2 vccd2 vssd2"
-    ],
     "MACRO_PLACEMENT_CFG": "dir::macro.cfg",
     "VERILOG_FILES_BLACKBOX": [
         "dir::src/defines.v",


### PR DESCRIPTION
More stringent validation on PDN_MACRO_CONNECTIONS shows that this variable was always kind of broken.