### PR TITLE
Set `PL_TARGET_DENSITY_PCT` explicitly for some designs

### DIFF
--- a/MS_DMAC_AHBL/config.json
+++ b/MS_DMAC_AHBL/config.json
@@ -5,5 +5,6 @@
     "CLOCK_PERIOD": 10,
     "FP_IO_MODE": "annealing",
     "FP_IO_MIN_DISTANCE": 2,
-    "FP_CORE_UTIL": 70
+    "FP_CORE_UTIL": 70,
+    "PL_TARGET_DENSITY_PCT": 80
 }

--- a/MS_SPI_XIP_CACHE/config.json
+++ b/MS_SPI_XIP_CACHE/config.json
@@ -7,5 +7,6 @@
     "CLOCK_PORT": "HCLK",
     "CLOCK_PERIOD": 10,
     "FP_IO_MODE": "annealing",
+    "PL_TARGET_DENSITY_PCT": 75,
     "FP_CORE_UTIL": 65
 }

--- a/blink/config.json
+++ b/blink/config.json
@@ -10,5 +10,5 @@
     "FP_PDN_VOFFSET": 7,
     "FP_PDN_HOFFSET": 7,
     "FP_PDN_SKIPTRIM": true,
-    "PL_TARGET_DENTIY_PCT": 60
+    "PL_TARGET_DENSITY_PCT": 60
 }

--- a/blink/config.json
+++ b/blink/config.json
@@ -9,5 +9,6 @@
     "CLOCK_PORT": "clk",
     "FP_PDN_VOFFSET": 7,
     "FP_PDN_HOFFSET": 7,
-    "FP_PDN_SKIPTRIM": true
+    "FP_PDN_SKIPTRIM": true,
+    "PL_TARGET_DENTIY_PCT": 60
 }


### PR DESCRIPTION
* Designs:
  * Explicitly set `PL_TARGET_DENSITY_PCT` to the value based of old calculation method as some designs had negative metric changes.