### PR TITLE
Fix instances being double-listed for `caravel_upw`

### DIFF
--- a/caravel_upw/config.json
+++ b/caravel_upw/config.json
@@ -59,13 +59,6 @@
                         1690
                     ],
                     "orientation": "N"
-                },
-                "mprj2": {
-                    "location": [
-                        1175,
-                        400
-                    ],
-                    "orientation": "N"
                 }
             },
             "gds": [
@@ -73,17 +66,14 @@
             ],
             "lef": [
                 "dir::macros/user_proj_example.lef"
+            ],
+            "vh": [
+                "dir::src/defines.v",
+                "dir::src/user_proj_example.v"
             ]
         },
         "user_proj_example2": {
             "instances": {
-                "mprj1": {
-                    "location": [
-                        1175,
-                        1690
-                    ],
-                    "orientation": "N"
-                },
                 "mprj2": {
                     "location": [
                         1175,
@@ -97,10 +87,13 @@
             ],
             "lef": [
                 "dir::macros/user_proj_example2.lef"
+            ],
+            "vh": [
+                "dir::src/defines.v",
+                "dir::src/user_proj_example2.v"
             ]
         }
     },
-    "EXTRA_VERILOG_MODELS": "dir::src/*.v",
     "RT_MAX_LAYER": "met4",
     "FP_PDN_CHECK_NODES": false,
     "SYNTH_ELABORATE_ONLY": true,

--- a/caravel_user_project_example_full/harden.py
+++ b/caravel_user_project_example_full/harden.py
@@ -55,11 +55,6 @@ def main(
     upe_state_out = upe_flow.start(tag=run_tag)
 
     user_proj_example = Macro.from_state(upe_state_out)
-
-    # TODO: Fix these hacks
-    user_proj_example.nl = [x.replace(".nl.v", ".pnl.v") for x in user_proj_example.nl]
-    user_proj_example.lib = []
-    
     user_proj_example.instantiate("mprj", (60, 15))
 
     upw_dir = os.path.join(__dir__, "src", "openlane", "user_project_wrapper")

--- a/caravel_user_project_example_full/harden.py
+++ b/caravel_user_project_example_full/harden.py
@@ -80,7 +80,7 @@ def main(
         pdk_root=pdk_root,
     )
     upw_flow.start(tag=run_tag)
-    
+
     runs_dir = os.path.join(__dir__, "runs")
     run_dir_final = os.path.join(runs_dir, run_tag)
     mkdirp(runs_dir)


### PR DESCRIPTION
* `caravel_upw`: Both macro instances were listed twice, once correctly and once as part of the wrong macro. This fixes that and adds the new `vh` view of the Macro