### PR TITLE
More new tests for macro black-boxing

### DIFF
--- a/aes_user_project_wrapper/config.json
+++ b/aes_user_project_wrapper/config.json
@@ -12,12 +12,6 @@
     "FP_PDN_MACRO_HOOKS": "mprj vccd2 vssd2 VPWR VGND",
     "MACROS": {
         "aes_example": {
-            "gds": [
-                "dir::./gds/aes_example.gds.gz"
-            ],
-            "lef": [
-                "dir::./lef/aes_example.lef"
-            ],
             "instances": {
                 "mprj": {
                     "location": [
@@ -27,6 +21,12 @@
                     "orientation": "N"
                 }
             },
+            "gds": [
+                "dir::./gds/aes_example.gds.gz"
+            ],
+            "lef": [
+                "dir::./lef/aes_example.lef"
+            ],
             "nl": [
                 "dir::./gl/aes_example.v"
             ],

--- a/cell_inverter/config.json
+++ b/cell_inverter/config.json
@@ -1,0 +1,12 @@
+{
+    "meta": {
+        "version": 2,
+        "flow": [
+            "Verilator.Lint",
+            "Yosys.JsonHeader",
+            "Yosys.Synthesis"
+        ]
+    },
+    "DESIGN_NAME": "inverter",
+    "VERILOG_FILES": "dir::src/*.v"
+}

--- a/cell_inverter/src/inverter.v
+++ b/cell_inverter/src/inverter.v
@@ -16,13 +16,9 @@ module inverter (
 `ifdef PDK_sky130A 
     inout VPWR,
     inout VGND,
-    inout VPB,
-    inout VNB,
 `elsif PDK_gf180mcuD
     inout VDD,
     inout VSS,
-    inout VNW,
-    inout VPW,
 `endif
 `endif
     input wire in,
@@ -33,8 +29,8 @@ module inverter (
     `ifdef USE_POWER_PINS
         .VPWR(VPWR),
         .VGND(VGND),
-        .VPB(VPB),
-        .VNB(VNB),
+        .VPB(VPWR),
+        .VNB(VGND),
     `endif
         .Y(out),
         .A(in)
@@ -44,8 +40,8 @@ module inverter (
     `ifdef USE_POWER_PINS
         .VDD(VDD),
         .VSS(VSS),
-        .VNW(VNW),
-        .VPW(VPW),
+        .VNW(VDD),
+        .VPW(VSS),
     `endif
         .ZN(out),
         .I(in)

--- a/cell_inverter/src/inverter.v
+++ b/cell_inverter/src/inverter.v
@@ -1,0 +1,55 @@
+// Copyright 2024 Efabless Corporation
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+module inverter (
+`ifdef USE_POWER_PINS
+`ifdef PDK_sky130A 
+    inout VPWR,
+    inout VGND,
+    inout VPB,
+    inout VNB,
+`elsif PDK_gf180mcuD
+    inout VDD,
+    inout VSS,
+    inout VNW,
+    inout VPW,
+`endif
+`endif
+    input wire in,
+    output out
+);
+`ifdef PDK_sky130A
+    sky130_fd_sc_hd__inv_1 inv(
+    `ifdef USE_POWER_PINS
+        .VPWR(VPWR),
+        .VGND(VGND),
+        .VPB(VPB),
+        .VNB(VNB),
+    `endif
+        .Y(out),
+        .A(in)
+    );
+`elsif PDK_gf180mcuD
+    gf180mcu_fd_sc_mcu7t5v0__inv_1 inv(
+    `ifdef USE_POWER_PINS
+        .VDD(VDD),
+        .VSS(VSS),
+        .VNW(VNW),
+        .VPW(VPW),
+    `endif
+        .ZN(out),
+        .I(in)
+    );
+`endif
+
+endmodule

--- a/dual_spm/integrate.py
+++ b/dual_spm/integrate.py
@@ -1,3 +1,17 @@
+#!/usr/bin/env python3
+# Copyright 2024 Efabless Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 import os
 
 from openlane.flows.classic import Classic

--- a/dual_spm/integrate.py
+++ b/dual_spm/integrate.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
+import click
 
 from openlane.flows.classic import Classic
 from openlane.common import ScopedFile
@@ -21,172 +22,184 @@ from openlane.logging import options
 
 __dir__ = os.path.dirname(__file__)
 
-options.set_condensed_mode(True)
 
-spm_v = ScopedFile(
-    contents="""
-    module spm #(parameter bits=32) (
-        input clk,
-        input rst,
-        input x,
-        input[bits-1: 0] a,
-        output y
-    );
-        wire[bits: 0] y_chain;
-        assign y_chain[0] = 0;
-        assign y = y_chain[bits];
+@click.command(context_settings={"ignore_unknown_options": True})
+@click.option("--pdk-root", type=click.Path(dir_okay=True, file_okay=False))
+@click.option("--run-tag", type=click.Path(dir_okay=True, file_okay=False))
+@click.argument("args", nargs=-1, type=click.UNPROCESSED)
+def main(
+    pdk_root,
+    run_tag,
+    args,
+):
+    options.set_condensed_mode(True)
 
-        wire[bits-1:0] a_flip;
-        generate 
-            for (genvar i = 0; i < bits; i = i + 1) begin : flip_block
-                assign a_flip[i] = a[bits - i - 1];
-            end 
-        endgenerate
-
-        DelayedSerialAdder dsa[bits-1:0](
-            .clk(clk),
-            .rst(rst),
-            .x(x),
-            .a(a_flip),
-            .y_in(y_chain[bits-1:0]),
-            .y_out(y_chain[bits:1])
+    spm_v = ScopedFile(
+        contents="""
+        module spm #(parameter bits=32) (
+            input clk,
+            input rst,
+            input x,
+            input[bits-1: 0] a,
+            output y
         );
+            wire[bits: 0] y_chain;
+            assign y_chain[0] = 0;
+            assign y = y_chain[bits];
 
-    endmodule
+            wire[bits-1:0] a_flip;
+            generate 
+                for (genvar i = 0; i < bits; i = i + 1) begin : flip_block
+                    assign a_flip[i] = a[bits - i - 1];
+                end 
+            endgenerate
 
-    module DelayedSerialAdder(
-        input clk,
-        input rst,
-        input x,
-        input a,
-        input y_in,
-        output reg y_out
-    );
-        reg lastCarry;
-        wire lastCarry_next;
-        wire y_out_next;
+            DelayedSerialAdder dsa[bits-1:0](
+                .clk(clk),
+                .rst(rst),
+                .x(x),
+                .a(a_flip),
+                .y_in(y_chain[bits-1:0]),
+                .y_out(y_chain[bits:1])
+            );
 
-        wire g = x & a;
-        assign {lastCarry_next, y_out_next} = g + y_in + lastCarry;
+        endmodule
 
-        always @ (posedge clk or negedge rst) begin
-            if (!rst) begin
-                lastCarry <= 1'b0;
-                y_out <= 1'b0;
-            end else begin
-                lastCarry <= lastCarry_next;
-                y_out <= y_out_next;
+        module DelayedSerialAdder(
+            input clk,
+            input rst,
+            input x,
+            input a,
+            input y_in,
+            output reg y_out
+        );
+            reg lastCarry;
+            wire lastCarry_next;
+            wire y_out_next;
+
+            wire g = x & a;
+            assign {lastCarry_next, y_out_next} = g + y_in + lastCarry;
+
+            always @ (posedge clk or negedge rst) begin
+                if (!rst) begin
+                    lastCarry <= 1'b0;
+                    y_out <= 1'b0;
+                end else begin
+                    lastCarry <= lastCarry_next;
+                    y_out <= y_out_next;
+                end
             end
-        end
-    endmodule
-"""
-)
-
-macro_flow = Classic(
-    {
-        "DESIGN_NAME": "spm",
-        "CLOCK_PORT": "clk",
-        "VERILOG_FILES": [spm_v],
-        "FP_PDN_CORE_RING": True,
-        "RUN_KLAYOUT_DRC": False,
-        "FP_PDN_CORE_RING_VWIDTH": 3.1,
-        "FP_PDN_CORE_RING_HWIDTH": 3.1,
-        "FP_PDN_CORE_RING_VOFFSET": 12.45,
-        "FP_PDN_CORE_RING_HOFFSET": 12.45,
-        "FP_PDN_CORE_RING_VSPACING": 1.7,
-        "FP_PDN_CORE_RING_HSPACING": 1.7,
-        "FP_PDN_VPITCH": 80,
-        "FP_PDN_HPITCH": 80,
-        "FP_PDN_VWIDTH": 3.2,
-        "FP_PDN_HWIDTH": 3.2,
-        "FP_PDN_VSPACING": 3.2,
-        "FP_PDN_HSPACING": 3.2,
-        "FP_MACRO_HORIZONTAL_HALO": 20,
-        "FP_MACRO_VERTICAL_HALO": 20,
-    },
-    design_dir=__dir__,
-    pdk="sky130A",
-)
-
-macro_state = macro_flow.start()
-# macro_state = State.loads(open("runs/spm/54-checker-lvs/state_out.json").read())
-
-spm = Macro.from_state(macro_state)
-spm.instantiate("spm_1", (150, 150))
-spm.instantiate("spm_2", (300, 300))
-
-integration_v = ScopedFile(
-    contents="""
-    module dual_spm(
-    `ifdef USE_POWER_PINS
-        inout VPWR,
-        inout VGND,
-    `endif
-        input clk,
-        input rstn,
-        input x1,
-        input x2,
-        input[31:0] a1,
-        input[31:0] a2,
-        output y1,
-        output y2
-    );
-        spm spm_1 (
-        `ifdef USE_POWER_PINS
-            .VPWR(VPWR),
-            .VGND(VGND),
-        `endif
-            .clk(clk),
-            .rst(rstn),
-            .x(x1),
-            .a(a1),
-            .y(y1)
-        );
-        spm spm_2 (
-        `ifdef USE_POWER_PINS
-            .VPWR(VPWR),
-            .VGND(VGND),
-        `endif
-            .clk(clk),
-            .rst(rstn),
-            .x(x2),
-            .a(a2),
-            .y(y2)
-        );
-    endmodule    
+        endmodule
     """
-)
+    )
 
-integration_flow = Classic(
-    {
-        "DESIGN_NAME": "dual_spm",
-        "CLOCK_PORT": "clk",
-        "VERILOG_FILES": [integration_v],
-        "MACROS": {"spm": spm},
-        "FP_SIZING": "absolute",
-        "DIE_AREA": [0, 0, 500, 500],
-        "FP_PDN_CORE_RING_VWIDTH": 3.1,
-        "FP_PDN_CORE_RING_HWIDTH": 3.1,
-        "FP_PDN_CORE_RING_VOFFSET": 12.45,
-        "FP_PDN_CORE_RING_HOFFSET": 12.45,
-        "FP_PDN_CORE_RING_VSPACING": 1.7,
-        "FP_PDN_CORE_RING_HSPACING": 1.7,
-        "FP_PDN_VWIDTH": 3.2,
-        "FP_PDN_HWIDTH": 3.2,
-        "FP_PDN_VSPACING": 3.2,
-        "FP_PDN_HSPACING": 3.2,
-        "FP_PDN_VPITCH": 40,
-        "FP_PDN_HPITCH": 40,
-        "FP_MACRO_HORIZONTAL_HALO": 20,
-        "FP_MACRO_VERTICAL_HALO": 20,
-        "FP_PDN_CHECK_NODES": False,
-        "RUN_IRDROP_REPORT": False,
-        "RUN_KLAYOUT_DRC": False,
-        "RUN_KLAYOUT_STREAMOUT": False,
-        "RUN_KLAYOUT_XOR": False,
-    },
-    design_dir=__dir__,
-    pdk="sky130A",
-)
+    macro_flow = Classic(
+        {
+            "DESIGN_NAME": "spm",
+            "CLOCK_PORT": "clk",
+            "VERILOG_FILES": [spm_v],
+            "FP_PDN_CORE_RING": True,
+            "RUN_KLAYOUT_DRC": False,
+            "FP_PDN_CORE_RING_VWIDTH": 3.1,
+            "FP_PDN_CORE_RING_HWIDTH": 3.1,
+            "FP_PDN_CORE_RING_VOFFSET": 12.45,
+            "FP_PDN_CORE_RING_HOFFSET": 12.45,
+            "FP_PDN_CORE_RING_VSPACING": 1.7,
+            "FP_PDN_CORE_RING_HSPACING": 1.7,
+            "FP_PDN_VPITCH": 80,
+            "FP_PDN_HPITCH": 80,
+            "FP_PDN_VWIDTH": 3.2,
+            "FP_PDN_HWIDTH": 3.2,
+            "FP_PDN_VSPACING": 3.2,
+            "FP_PDN_HSPACING": 3.2,
+            "FP_MACRO_HORIZONTAL_HALO": 20,
+            "FP_MACRO_VERTICAL_HALO": 20,
+        },
+        design_dir=__dir__,
+        pdk="sky130A",
+        pdk_root=pdk_root,
+    )
 
-integration = integration_flow.start()
+    macro_state = macro_flow.start(tag=os.path.join(run_tag, "macro"))
+    # macro_state = State.loads(open("runs/spm/54-checker-lvs/state_out.json").read())
+
+    spm = Macro.from_state(macro_state)
+    spm.instantiate("spm_1", (150, 150))
+    spm.instantiate("spm_2", (300, 300))
+
+    integration_v = ScopedFile(
+        contents="""
+        module dual_spm(
+        `ifdef USE_POWER_PINS
+            inout VPWR,
+            inout VGND,
+        `endif
+            input clk,
+            input rstn,
+            input x1,
+            input x2,
+            input[31:0] a1,
+            input[31:0] a2,
+            output y1,
+            output y2
+        );
+            spm spm_1 (
+            `ifdef USE_POWER_PINS
+                .VPWR(VPWR),
+                .VGND(VGND),
+            `endif
+                .clk(clk),
+                .rst(rstn),
+                .x(x1),
+                .a(a1),
+                .y(y1)
+            );
+            spm spm_2 (
+            `ifdef USE_POWER_PINS
+                .VPWR(VPWR),
+                .VGND(VGND),
+            `endif
+                .clk(clk),
+                .rst(rstn),
+                .x(x2),
+                .a(a2),
+                .y(y2)
+            );
+        endmodule    
+        """
+    )
+
+    integration_flow = Classic(
+        {
+            "DESIGN_NAME": "dual_spm",
+            "CLOCK_PORT": "clk",
+            "VERILOG_FILES": [integration_v],
+            "MACROS": {"spm": spm},
+            "FP_SIZING": "absolute",
+            "DIE_AREA": [0, 0, 500, 500],
+            "FP_PDN_CORE_RING_VWIDTH": 3.1,
+            "FP_PDN_CORE_RING_HWIDTH": 3.1,
+            "FP_PDN_CORE_RING_VOFFSET": 12.45,
+            "FP_PDN_CORE_RING_HOFFSET": 12.45,
+            "FP_PDN_CORE_RING_VSPACING": 1.7,
+            "FP_PDN_CORE_RING_HSPACING": 1.7,
+            "FP_PDN_VWIDTH": 3.2,
+            "FP_PDN_HWIDTH": 3.2,
+            "FP_PDN_VSPACING": 3.2,
+            "FP_PDN_HSPACING": 3.2,
+            "FP_PDN_VPITCH": 40,
+            "FP_PDN_HPITCH": 40,
+            "FP_MACRO_HORIZONTAL_HALO": 20,
+            "FP_MACRO_VERTICAL_HALO": 20,
+            "FP_PDN_CHECK_NODES": False,
+            "RUN_IRDROP_REPORT": False,
+            "RUN_KLAYOUT_DRC": False,
+            "RUN_KLAYOUT_STREAMOUT": False,
+            "RUN_KLAYOUT_XOR": False,
+        },
+        design_dir=__dir__,
+        pdk="sky130A",
+        pdk_root=pdk_root,
+    )
+
+    integration_flow.start(tag=os.path.join(run_tag, "integration"))

--- a/dual_spm/integrate.py
+++ b/dual_spm/integrate.py
@@ -203,3 +203,7 @@ def main(
     )
 
     integration_flow.start(tag=os.path.join(run_tag, "integration"))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
* Reorganized `aes_user_project_wrapper/config.json`
* New design `dual_spm`, full one-script integration example for the fastest test set
* New design `cell_inverter`, Synthesis-only flow for one hand-instantiated cell for both sky130A and gf180mcuD